### PR TITLE
Fix code scanning alert no. 14: Log injection

### DIFF
--- a/server/routes/dxfUpload.js
+++ b/server/routes/dxfUpload.js
@@ -36,7 +36,8 @@ const uploader = multer({
 async function deleteFile(filePath) {
     try {
         await fs.unlink(filePath);
-        console.log(`Deleted file: ${filePath}`);
+        const sanitizedFilePath = filePath.replace(/\n|\r/g, "");
+        console.log(`Deleted file: ${sanitizedFilePath}`);
     } catch (error) {
         console.error(`Error deleting file ${filePath}:`, error);
     }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/14](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/14)

To fix the log injection issue, we need to sanitize the `filePath` before logging it. Specifically, we should remove any newline characters from the `filePath` to prevent log injection attacks. This can be done using the `String.prototype.replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
