### PR TITLE
Fix code scanning alert no. 15: Log injection

### DIFF
--- a/server/routes/dxfUpload.js
+++ b/server/routes/dxfUpload.js
@@ -38,7 +38,8 @@ async function deleteFile(filePath) {
         await fs.unlink(filePath);
         console.log(`Deleted file: ${filePath}`);
     } catch (error) {
-        console.error(`Error deleting file ${filePath}:`, error);
+        const sanitizedFilePath = filePath.replace(/\n|\r/g, "");
+        console.error(`Error deleting file ${sanitizedFilePath}:`, error);
     }
 }
 


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/15](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/15)

To fix the log injection issue, we need to sanitize the `filePath` before logging it. Specifically, we should remove any newline characters from the `filePath` to prevent log injection attacks. This can be done using `String.prototype.replace` to ensure no line endings are present in the user input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
