### PR TITLE
Fix code scanning alert no. 7: Log injection

### DIFF
--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -39,7 +39,8 @@ async function deleteFiles(files) {
             await fs.unlink(file.path);
             // console.log(`Deleted file: ${file.path}`);
         } catch (error) {
-            console.error(`Error deleting file ${file.path}:`, error);
+            const sanitizedFilePath = file.path.replace(/\n|\r/g, "");
+            console.error(`Error deleting file ${sanitizedFilePath}:`, error);
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/7](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/7)

To fix the log injection issue, we need to sanitize the `file.path` value before logging it. Specifically, we should remove any newline characters from the `file.path` to prevent log injection attacks. This can be done using `String.prototype.replace` to strip out newline characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
