### PR TITLE
Fix code scanning alert no. 16: Log injection

### DIFF
--- a/server/services/dxfProcessor.js
+++ b/server/services/dxfProcessor.js
@@ -12,7 +12,8 @@ const ATTRIBUTE_MAPPING = {
 };
 
 async function processDXF(filePath) {
-    console.log(`Processing DXF file: ${filePath}`);
+    const sanitizedFilePath = filePath.replace(/\n|\r/g, "");
+    console.log(`Processing DXF file: ${sanitizedFilePath}`);
     try {
         const dxfContent = await fs.readFile(filePath, 'utf-8');
         const parser = new DxfParser();


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/16](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/16)

To fix the log injection issue, we need to sanitize the `filePath` before logging it. Specifically, we should remove any newline characters from the `filePath` to prevent log injection. This can be done using the `String.prototype.replace` method.

1. In the `processDXF` function in `server/services/dxfProcessor.js`, sanitize the `filePath` by removing newline characters before logging it.
2. No additional imports or dependencies are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
