### PR TITLE
Fix code scanning alert no. 20: Log injection

### DIFF
--- a/server/services/shapefileProcessor.js
+++ b/server/services/shapefileProcessor.js
@@ -9,7 +9,8 @@ const reprojectionHelper = require('../utils/reprojectionHelper');
 
 
 async function convertShapefileToGeoJSON(shpPath) {
-    console.log(`Zpracování SHP: ${shpPath}`);
+    const sanitizedShpPath = shpPath.replace(/\n|\r/g, "");
+    console.log(`Zpracování SHP: ${sanitizedShpPath}`);
     try {
         const source = await shapefile.open(shpPath);
 
@@ -108,7 +109,7 @@ async function convertShapefileToGeoJSON(shpPath) {
         return { features: reprojectedFeatures, attributes, originalEPSG, currentEPSG, reprojected };
 
     } catch (error) {
-        console.error(`Došlo k chybě při zpracování ${shpPath}:`, error);
+        console.error(`Došlo k chybě při zpracování ${sanitizedShpPath}:`, error);
         throw error;
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/20](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/20)

To fix the log injection issue, we need to sanitize the `shpPath` before logging it. Specifically, we should remove any newline characters from the `shpPath` to prevent log forging. This can be done using `String.prototype.replace` to strip out newline characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
