### PR TITLE
Fix code scanning alert no. 21: Log injection

### DIFF
--- a/server/services/shapefileProcessor.js
+++ b/server/services/shapefileProcessor.js
@@ -108,7 +108,8 @@ async function convertShapefileToGeoJSON(shpPath) {
         return { features: reprojectedFeatures, attributes, originalEPSG, currentEPSG, reprojected };
 
     } catch (error) {
-        console.error(`Došlo k chybě při zpracování ${shpPath}:`, error);
+        const sanitizedShpPath = shpPath.replace(/\n|\r/g, "");
+        console.error(`Došlo k chybě při zpracování ${sanitizedShpPath}:`, error);
         throw error;
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/21](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/21)

To fix the log injection issue, we need to sanitize the `shpPath` before logging it. Specifically, we should remove any newline characters from the `shpPath` to prevent log forging. This can be done using `String.prototype.replace` to strip out newline characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
