### PR TITLE
Fix code scanning alert no. 11: Uncontrolled data used in path expression

### DIFF
--- a/server/routes/dxfUpload.js
+++ b/server/routes/dxfUpload.js
@@ -35,8 +35,12 @@ const uploader = multer({
 // Funkce pro mazání souborů
 async function deleteFile(filePath) {
     try {
-        await fs.unlink(filePath);
-        console.log(`Deleted file: ${filePath}`);
+        const resolvedPath = path.resolve(filePath);
+        if (!resolvedPath.startsWith(path.resolve(config.UPLOAD_DIR))) {
+            throw new Error(`Attempt to delete file outside of upload directory: ${filePath}`);
+        }
+        await fs.unlink(resolvedPath);
+        console.log(`Deleted file: ${resolvedPath}`);
     } catch (error) {
         console.error(`Error deleting file ${filePath}:`, error);
     }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/11](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/11)

To fix the problem, we need to ensure that the `filePath` used in the `deleteFile` function is validated to be within a safe directory. We can achieve this by resolving the `filePath` to an absolute path and then checking that it starts with the root upload directory. This will prevent path traversal attacks by ensuring that the file to be deleted is within the intended directory.

1. Use `path.resolve` to normalize the `filePath`.
2. Check that the resolved `filePath` starts with the `config.UPLOAD_DIR`.
3. If the check fails, log an error and do not attempt to delete the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
