### PR TITLE
Fix code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/server/services/dxfProcessor.js
+++ b/server/services/dxfProcessor.js
@@ -11,10 +11,18 @@ const ATTRIBUTE_MAPPING = {
     'name': 'Název'
 };
 
+const path = require('path');
+const ROOT_DIR = path.resolve(__dirname, '../../uploads'); // Adjust the path as needed
+
 async function processDXF(filePath) {
     console.log(`Processing DXF file: ${filePath}`);
     try {
-        const dxfContent = await fs.readFile(filePath, 'utf-8');
+        const resolvedPath = path.resolve(ROOT_DIR, filePath);
+        const normalizedPath = await fs.realpath(resolvedPath);
+        if (!normalizedPath.startsWith(ROOT_DIR)) {
+            throw new Error('Invalid file path');
+        }
+        const dxfContent = await fs.readFile(normalizedPath, 'utf-8');
         const parser = new DxfParser();
         const dxf = parser.parse(dxfContent);
 


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/12](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/12)

To fix the problem, we need to ensure that the `filePath` used in `processDXF` is validated to be within a safe root directory. This can be achieved by resolving the path and checking that it starts with the intended root directory. We will use `path.resolve` and `fs.realpathSync` to normalize the path and then verify it.

1. In `server/services/dxfProcessor.js`, modify the `processDXF` function to validate the `filePath`.
2. Ensure the root directory is defined and used for validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
