### PR TITLE
Fix code scanning alert no. 9: Use of externally-controlled format string

### DIFF
--- a/server/routes/dxfUpload.js
+++ b/server/routes/dxfUpload.js
@@ -38,7 +38,7 @@ async function deleteFile(filePath) {
         await fs.unlink(filePath);
         console.log(`Deleted file: ${filePath}`);
     } catch (error) {
-        console.error(`Error deleting file ${filePath}:`, error);
+        console.error('Error deleting file %s:', filePath, error);
     }
 }
 


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/9](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/9)

To fix the problem, we should avoid directly embedding the user-controlled `filePath` in the format string. Instead, we can use a `%s` specifier in the format string and pass the `filePath` as an argument to ensure it is treated as a string. This approach sanitizes the input and prevents any unintended format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
