### PR TITLE
Fix code scanning alert no. 5: Use of externally-controlled format string

### DIFF
--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -39,7 +39,7 @@ async function deleteFiles(files) {
             await fs.unlink(file.path);
             // console.log(`Deleted file: ${file.path}`);
         } catch (error) {
-            console.error(`Error deleting file ${file.path}:`, error);
+            console.error('Error deleting file %s:', file.path, error);
         }
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/5](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/5)

To fix the problem, we should avoid directly incorporating the user-controlled `file.path` into the format string. Instead, we can use a `%s` specifier in the format string and pass the `file.path` as a separate argument to ensure it is treated as a string. This approach will prevent any unexpected format specifiers from being processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
