### PR TITLE
Fix code scanning alert no. 10: Use of externally-controlled format string

### DIFF
--- a/server/services/dxfProcessor.js
+++ b/server/services/dxfProcessor.js
@@ -28,7 +28,7 @@ async function processDXF(filePath) {
             fileName: filePath.split('/').pop()
         };
     } catch (error) {
-        console.error(`Error processing DXF file ${filePath}:`, error);
+        console.error('Error processing DXF file %s:', filePath, error);
         throw error;
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/10](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/10)

To fix the problem, we should avoid directly embedding the `filePath` in the format string. Instead, we can use a `%s` specifier in the format string and pass the `filePath` as an argument to ensure it is treated as a string. This approach prevents any format specifiers in the `filePath` from being interpreted by the logging function.

**Steps to fix:**
1. Modify the `console.error` statement in `server/services/dxfProcessor.js` to use a `%s` specifier for the `filePath`.
2. Pass the `filePath` as an additional argument to the `console.error` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
