### PR TITLE
Fix code scanning alert no. 18: Uncontrolled data used in path expression

### DIFF
--- a/server/utils/epsgHelper.js
+++ b/server/utils/epsgHelper.js
@@ -27,11 +27,20 @@ const S_JTSK_VARIANTS = [
     { epsg: 102067, searchText: 'S-JTSK_Krovak_East_North' }
 ];
 
+const path = require('path');
+
 async function getEPSG(filePath, entities = null) {
     const fileExtension = filePath.split('.').pop().toLowerCase();
+    const rootDir = path.resolve(config.UPLOAD_DIR);
+    const resolvedPath = path.resolve(rootDir, filePath);
+
+    if (!resolvedPath.startsWith(rootDir)) {
+        console.warn('Invalid file path.');
+        return null;
+    }
 
     if (fileExtension === 'shp') {
-        return getEPSGForSHP(filePath);
+        return getEPSGForSHP(resolvedPath);
     } else if (fileExtension === 'dxf') {
         return getEPSGForDXF(entities);
     } else {
@@ -42,11 +51,19 @@ async function getEPSG(filePath, entities = null) {
 
 async function getEPSGForSHP(shpPath) {
     const prjPath = shpPath.replace('.shp', '.prj');
+    const rootDir = path.resolve(config.UPLOAD_DIR);
+    const resolvedPrjPath = path.resolve(rootDir, prjPath);
+
+    if (!resolvedPrjPath.startsWith(rootDir)) {
+        console.warn('Invalid PRJ file path.');
+        return null;
+    }
+
     let epsg = null;
 
     try {
         // Načtení obsahu PRJ souboru
-        const prjContent = await fs.readFile(prjPath, 'utf8');
+        const prjContent = await fs.readFile(resolvedPrjPath, 'utf8');
 
         // Získání EPSG kódu pomocí prj2epsg
         const epsgCode = prj2epsg.fromPRJ(prjContent);


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/18](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/18)

To fix the problem, we need to ensure that the `filePath` is validated and sanitized before it is used to construct other paths or read files. The best way to do this is to resolve the `filePath` to an absolute path and ensure it is within a designated safe directory. This can be achieved using the `path.resolve` and `fs.realpathSync` functions.

1. Normalize the `filePath` using `path.resolve` to remove any ".." segments.
2. Check that the normalized path starts with the root directory (e.g., `config.UPLOAD_DIR`).
3. If the path is valid, proceed with reading the file; otherwise, handle the error appropriately.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
