### PR TITLE
Fix code scanning alert no. 19: Use of externally-controlled format string

### DIFF
--- a/server/services/shapefileProcessor.js
+++ b/server/services/shapefileProcessor.js
@@ -108,7 +108,7 @@ async function convertShapefileToGeoJSON(shpPath) {
         return { features: reprojectedFeatures, attributes, originalEPSG, currentEPSG, reprojected };
 
     } catch (error) {
-        console.error(`Došlo k chybě při zpracování ${shpPath}:`, error);
+        console.error('Došlo k chybě při zpracování %s:', shpPath, error);
         throw error;
     }
 }


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/19](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/19)

To fix the problem, we should use the `%s` format specifier in the `console.error` call and pass the `shpPath` as a separate argument. This ensures that any user-controlled input is safely included in the log message without being interpreted as a format specifier.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
