### PR TITLE
Fix code scanning alert no. 8: Type confusion through parameter tampering

### DIFF
--- a/server/routes/upload.js
+++ b/server/routes/upload.js
@@ -46,7 +46,7 @@ async function deleteFiles(files) {
 
 // POST route pro upload
 router.post('/', uploader.array('shpFiles', config.MAX_FILES), async (req, res) => {
-    if (!req.files || req.files.length === 0) {
+    if (!Array.isArray(req.files) || req.files.length === 0) {
         return res.status(400).json({ error: 'Nebyly nahrány žádné soubory.' });
     }
 


### PR DESCRIPTION
Fixes [https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/8](https://github.com/ARUP-CAS/aiscr-gis-convert/security/code-scanning/8)

To fix the problem, we need to ensure that `req.files` is an array before performing any operations on it. This can be done by adding a type check at the beginning of the route handler. If `req.files` is not an array, we should return a 400 Bad Request response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
